### PR TITLE
update IAM policy creation script and current README

### DIFF
--- a/aws-attach-roles/README-attach-roles.md
+++ b/aws-attach-roles/README-attach-roles.md
@@ -4,32 +4,75 @@ There are multiple methods for doing this, if the method below does not fit your
 
 Using aws with IAM roles attached to service accounts:
 
-Enable oidc provider and create service accounts
+## Prerequisites:
+
+1. You have Amazon EKS cluster set up using eksctl. If you have Amazon EKS cluster set up via different method, please refer to AWS documentation at [Enable IAM roles for Service Accounts (IRSA) on the EKS cluster](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-enable-IAM.html)
+2. You have approriate IAM permissions to manage Amazon EKS cluster and manage,create and assign AWS IAM.
+3. Clone this repository into your machine and navigate to POC-COMMON-CONFIGURATION-TEST/aws-attach-roles
+4. Remember to update cloud-integration.jon with approriate information of your Athena set up for Cost Usage Report (CUR). For more information, please refer to this [documentation](https://guide.kubecost.com/hc/en-us/articles/4407595928087-AWS-Cloud-Integration)
+
+## Instructions:
+
+`AWS_object_store_bucket="<your-object-store-bucket-name>"`
+`AWS-REGION="<your-desired-aws-region>"`
+`YOUR-CLUSTER-NAME="<your-eks-cluster-name>"`
+
+1. Create Object store S3 bucket to store Thanos data:
+
+`aws s3 mb s3://${AWS_object_store_bucket} --region `
+
+1. Update configuration of these files: cloud-integration.json, kubecost-athena-policy.json, kubecost-s3-thanos-policy.json, object-store.yaml, productkey.json (optional if it is only for evaluation) accordingly with your information. The values that need to be updated is in <....>
+
+2. Run the following commands to create approriate policy:
+
 ```sh
+cd poc-common-configuration/aws-attach-roles
+aws iam create-policy --policy-name kubecost-athena-policy --policy-document file://kubecost-athena-policy.json
+aws iam create-policy --policy-name kubecost-s3-thanos-policy --policy-document file://kubecost-s3-thanos-policy.json
+```
+
+1. Enable oidc provider for your cluster:
+
+```
 kubectl create ns kubecost
 eksctl utils associate-iam-oidc-provider \
-    --cluster jesse-eks5 --region us-east-2 \
+    --cluster ${YOUR-CLUSTER-NAME} --region ${AWS-REGION} \
     --approve
+```
+1. Create required IAM service accounts. Please remember to replace 1111111111 with your actual AWS account ID #:
+
+```
 eksctl create iamserviceaccount \
     --name kubecost-serviceaccount-cur-athena-thanos \
     --namespace kubecost \
-    --cluster jesse-eks5 --region us-east-2 \
-    --attach-policy-arn arn:aws:iam::1111111111:policy/kubecost-cur-policy \
-    --attach-policy-arn arn:aws:iam::1111111111:policy/kubecost-athena-policy \
-    --attach-policy-arn arn:aws:iam::1111111111:policy/kubecost-s3-thanos-policy \
+    --cluster ${YOUR-CLUSTER-NAME} --region ${AWS-REGION} \
+    --attach-policy-arn arn:aws:iam::297945954695:policy/kubecost-athena-policy \
+    --attach-policy-arn arn:aws:iam::297945954695:policy/kubecost-s3-thanos-policy \
+    --override-existing-serviceaccounts \
     --approve
+```
+```
 eksctl create iamserviceaccount \
     --name kubecost-serviceaccount-thanos \
     --namespace kubecost \
-    --cluster jesse-eks5 --region us-east-2 \
-    --attach-policy-arn arn:aws:iam::1111111111:policy/kubecost-s3-thanos-policy \
+    --cluster ${YOUR-CLUSTER-NAME} --region ${AWS-REGION} \
+    --attach-policy-arn arn:aws:iam::297945954695:policy/kubecost-s3-thanos-policy \
+    --override-existing-serviceaccounts \
     --approve
 ```
 
-Install kubecost:
+1. Create required secret to store the configuration:
+
 ```sh
 kubectl create secret generic kubecost-thanos -n kubecost --from-file=object-store.yaml
-kubectl create secret generic aws-service-key -n kubecost --from-file=service-key.json
 kubectl create secret generic cloud-integration -n kubecost --from-file=cloud-integration.json
-helm upgrade --install kubecost kubecost/cost-analyzer --namespace kubecost -f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/master/cost-analyzer/values-thanos.yaml -f values-amazon-primary.yaml
+```
+
+1. Install kubecost:
+
+```
+helm upgrade --install kubecost kubecost/cost-analyzer \
+--namespace kubecost \
+-f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/master/cost-analyzer/values-thanos.yaml \
+-f values-amazon-primary.yaml
 ```

--- a/aws-attach-roles/README-attach-roles.md
+++ b/aws-attach-roles/README-attach-roles.md
@@ -13,17 +13,21 @@ Using aws with IAM roles attached to service accounts:
 
 ## Instructions:
 
-`AWS_object_store_bucket="<your-object-store-bucket-name>"`
-`AWS-REGION="<your-desired-aws-region>"`
-`YOUR-CLUSTER-NAME="<your-eks-cluster-name>"`
+0. Set up necessary ENV Variable:
+
+```
+AWS_object_store_bucket="<your-object-store-bucket-name>"
+AWS-REGION="<your-desired-aws-region>"
+YOUR-CLUSTER-NAME="<your-eks-cluster-name>"
+```
 
 1. Create Object store S3 bucket to store Thanos data:
 
 `aws s3 mb s3://${AWS_object_store_bucket} --region `
 
-1. Update configuration of these files: cloud-integration.json, kubecost-athena-policy.json, kubecost-s3-thanos-policy.json, object-store.yaml, productkey.json (optional if it is only for evaluation) accordingly with your information. The values that need to be updated is in <....>
+2. Update configuration of these files: cloud-integration.json, kubecost-athena-policy.json, kubecost-s3-thanos-policy.json, object-store.yaml, productkey.json (optional if it is only for evaluation) accordingly with your information. The values that need to be updated is in <....>
 
-2. Run the following commands to create approriate policy:
+3. Run the following commands to create approriate policy:
 
 ```sh
 cd poc-common-configuration/aws-attach-roles
@@ -31,7 +35,7 @@ aws iam create-policy --policy-name kubecost-athena-policy --policy-document fil
 aws iam create-policy --policy-name kubecost-s3-thanos-policy --policy-document file://kubecost-s3-thanos-policy.json
 ```
 
-1. Enable oidc provider for your cluster:
+4. Enable oidc provider for your cluster:
 
 ```
 kubectl create ns kubecost
@@ -39,7 +43,7 @@ eksctl utils associate-iam-oidc-provider \
     --cluster ${YOUR-CLUSTER-NAME} --region ${AWS-REGION} \
     --approve
 ```
-1. Create required IAM service accounts. Please remember to replace 1111111111 with your actual AWS account ID #:
+5. Create required IAM service accounts. Please remember to replace 1111111111 with your actual AWS account ID #:
 
 ```
 eksctl create iamserviceaccount \
@@ -61,14 +65,14 @@ eksctl create iamserviceaccount \
     --approve
 ```
 
-1. Create required secret to store the configuration:
+6. Create required secret to store the configuration:
 
 ```sh
 kubectl create secret generic kubecost-thanos -n kubecost --from-file=object-store.yaml
 kubectl create secret generic cloud-integration -n kubecost --from-file=cloud-integration.json
 ```
 
-1. Install kubecost:
+7. Install kubecost:
 
 ```
 helm upgrade --install kubecost kubecost/cost-analyzer \

--- a/aws-attach-roles/cloud-integration.json
+++ b/aws-attach-roles/cloud-integration.json
@@ -1,11 +1,11 @@
 {
     "aws": [
         {
-            "athenaBucketName": "s3://AWS_cloud_integration_athenaBucketName",
-            "athenaRegion": "AWS_cloud_integration_athenaRegion",
-            "athenaDatabase": "AWS_cloud_integration_athenaDatabase",
-            "athenaTable": "AWS_cloud_integration_athenaBucketName",
-            "projectID": "AWS_cloud_integration_athena_projectID"
+            "athenaBucketName": "s3://<AWS_cloud_integration_athenaBucketName>",
+            "athenaRegion": "<AWS_cloud_integration_athenaRegion>",
+            "athenaDatabase": "<AWS_cloud_integration_athenaDatabase>",
+            "athenaTable": "<AWS_cloud_integration_athenaTable>",
+            "projectID": "<AWS_account_ID>"
         }
     ]
 }

--- a/aws-attach-roles/kubecost-athena-policy.json
+++ b/aws-attach-roles/kubecost-athena-policy.json
@@ -1,0 +1,72 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AthenaAccess",
+      "Effect": "Allow",
+      "Action": [
+        "athena:*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Sid": "ReadAccessToAthenaCurDataViaGlue",
+      "Effect": "Allow",
+      "Action": [
+        "glue:GetDatabase*",
+        "glue:GetTable*",
+        "glue:GetPartition*",
+        "glue:GetUserDefinedFunction",
+        "glue:BatchGetPartition"
+      ],
+      "Resource": [
+        "arn:aws:glue:*:*:catalog",
+        "arn:aws:glue:*:*:database/athenacurcfn*",
+        "arn:aws:glue:*:*:table/athenacurcfn*/*"
+      ]
+    },
+    {
+      "Sid": "AthenaQueryResultsOutput",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListMultipartUploadParts",
+        "s3:AbortMultipartUpload",
+        "s3:CreateBucket",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::aws-athena-query-results-*"
+      ]
+    },
+    {
+      "Sid": "S3ReadAccessToAwsBillingData",
+      "Effect": "Allow",
+      "Action": [
+        "s3:Get*",
+        "s3:List*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::linh-athena-result/*"
+      ]
+    },
+    {
+      "Sid": "SpotDataAccess",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListAllMyBuckets",
+        "s3:ListBucket",
+        "s3:HeadBucket",
+        "s3:HeadObject",
+        "s3:List*",
+        "s3:Get*"
+      ],
+      "Resource": "arn:aws:s3:::linh-athena-result/*"
+    }
+  ]
+}

--- a/aws-attach-roles/kubecost-s3-thanos-policy.json
+++ b/aws-attach-roles/kubecost-s3-thanos-policy.json
@@ -1,0 +1,20 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Statement",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetObject",
+                "s3:DeleteObject",
+                "s3:PutObject",
+                "s3:PutObjectAcl"
+            ],
+            "Resource": [
+                "arn:aws:s3:::<AWS_object_store_bucket>/*",
+                "arn:aws:s3:::<AWS_object_store_bucket>"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Change logs:
- Update script to create IAM policy creation.
- Update command to create S3 bucket for Thanos.
- Update README file with more clarification and fix some hard code values in the command with some enhancements.
- Add 2 policy files to support the policy creation scripts
- Update configuration files value to match with new README contents

Testing:
Deploy on Amazon EKS successfully