### PR TITLE
Disable KSM pod by default

### DIFF
--- a/aws-attach-roles/values-amazon-primary.yaml
+++ b/aws-attach-roles/values-amazon-primary.yaml
@@ -15,6 +15,8 @@ kubecostProductConfigs:
   # awsSpotDataPrefix: dev
   # serviceKeySecretName: aws-service-key # Used for Spot Data Feed and Unattached Disks/IP Addresses
 prometheus:
+  kube-state-metrics:
+    disabled: true
   server:
     global:
       external_labels:

--- a/aws-attach-roles/values-amazon-primary.yaml
+++ b/aws-attach-roles/values-amazon-primary.yaml
@@ -14,7 +14,15 @@ kubecostProductConfigs:
   # awsSpotDataBucket: AWS_kubecostProductConfigs_awsSpotDataBucket
   # awsSpotDataPrefix: dev
   # serviceKeySecretName: aws-service-key # Used for Spot Data Feed and Unattached Disks/IP Addresses
+# kubecostMetrics:
+  # emitKsmV1Metrics: true # emit all KSM metrics in KSM v1. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 prometheus:
+  # Note: Even though we are disabling our bundled version of kube-state-metrics, Kubecost still emits v1 metrics.
+  # Care will need to be taken in environments that already have KSM deployed.
+  # For more information, see: https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  kubeStateMetrics:
+    enabled: false
   kube-state-metrics:
     disabled: true
   server:

--- a/aws-attach-roles/values-amazon-secondary.yaml
+++ b/aws-attach-roles/values-amazon-secondary.yaml
@@ -20,6 +20,8 @@ global:
     enabled: false
     proxy: false
 prometheus:
+  kube-state-metrics:
+    disabled: true
   server:
     global:
       external_labels:

--- a/aws-attach-roles/values-amazon-secondary.yaml
+++ b/aws-attach-roles/values-amazon-secondary.yaml
@@ -19,7 +19,15 @@ global:
   grafana:
     enabled: false
     proxy: false
+# kubecostMetrics:
+  # emitKsmV1Metrics: true # emit all KSM metrics in KSM v1. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 prometheus:
+  # Note: Even though we are disabling our bundled version of kube-state-metrics, Kubecost still emits v1 metrics.
+  # Care will need to be taken in environments that already have KSM deployed.
+  # For more information, see: https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  kubeStateMetrics:
+    enabled: false
   kube-state-metrics:
     disabled: true
   server:

--- a/aws/values-amazon-primary.yaml
+++ b/aws/values-amazon-primary.yaml
@@ -17,7 +17,7 @@ kubecostModel:
   # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 prometheus:
   kube-state-metrics:
-    enabled: false
+    disabled: true
   server:
     global:
       external_labels:

--- a/aws/values-amazon-primary.yaml
+++ b/aws/values-amazon-primary.yaml
@@ -16,6 +16,11 @@ kubecostModel:
   # emitKsmV1Metrics: true # emit all KSM metrics in KSM v1. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
   # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 prometheus:
+  # Note: Even though we are disabling our bundled version of kube-state-metrics, Kubecost still emits v1 metrics.
+  # Care will need to be taken in environments that already have KSM deployed.
+  # For more information, see: https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  kubeStateMetrics:
+    enabled: false
   kube-state-metrics:
     disabled: true
   server:

--- a/aws/values-amazon-primary.yaml
+++ b/aws/values-amazon-primary.yaml
@@ -12,6 +12,9 @@ kubecostProductConfigs:
   # serviceKeySecretName: aws-service-key # optional, used for Spot Data Feed and Unattached Disks/IP Addresses
 kubecostModel:
   etlCloudAsset: false # set to true to enable kubecost to include out-of-cluster cloud resources  (uses more memory)
+# kubecostMetrics:
+  # emitKsmV1Metrics: true # emit all KSM metrics in KSM v1. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 prometheus:
   kube-state-metrics:
     enabled: false

--- a/aws/values-amazon-primary.yaml
+++ b/aws/values-amazon-primary.yaml
@@ -13,9 +13,8 @@ kubecostProductConfigs:
 kubecostModel:
   etlCloudAsset: false # set to true to enable kubecost to include out-of-cluster cloud resources  (uses more memory)
 prometheus:
-  # disable KSM if there is an existing deployment
-  # kube-state-metrics:
-  #   enabled: false
+  kube-state-metrics:
+    enabled: false
   server:
     global:
       external_labels:

--- a/aws/values-amazon-secondary.yaml
+++ b/aws/values-amazon-secondary.yaml
@@ -20,9 +20,8 @@ global:
     enabled: false
     proxy: false
 prometheus:
-  # disable KSM if there is an existing deployment
-  # kube-state-metrics:
-  #   enabled: false
+  kube-state-metrics:
+    enabled: false
   server:
     global:
       external_labels:

--- a/aws/values-amazon-secondary.yaml
+++ b/aws/values-amazon-secondary.yaml
@@ -15,14 +15,19 @@ kubecostModel:
   etl: false
   etlCloudAsset: false
   maxQueryConcurrency: 1
-# kubecostMetrics:
-  # emitKsmV1Metrics: true # emit all KSM metrics in KSM v1. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
-  # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 global:
   grafana:
     enabled: false
     proxy: false
+# kubecostMetrics:
+  # emitKsmV1Metrics: true # emit all KSM metrics in KSM v1. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 prometheus:
+  # Note: Even though we are disabling our bundled version of kube-state-metrics, Kubecost still emits v1 metrics.
+  # Care will need to be taken in environments that already have KSM deployed.
+  # For more information, see: https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  kubeStateMetrics:
+    enabled: false
   kube-state-metrics:
     disabled: true
   server:

--- a/aws/values-amazon-secondary.yaml
+++ b/aws/values-amazon-secondary.yaml
@@ -24,7 +24,7 @@ global:
     proxy: false
 prometheus:
   kube-state-metrics:
-    enabled: false
+    disabled: true
   server:
     global:
       external_labels:

--- a/aws/values-amazon-secondary.yaml
+++ b/aws/values-amazon-secondary.yaml
@@ -15,6 +15,9 @@ kubecostModel:
   etl: false
   etlCloudAsset: false
   maxQueryConcurrency: 1
+# kubecostMetrics:
+  # emitKsmV1Metrics: true # emit all KSM metrics in KSM v1. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 global:
   grafana:
     enabled: false

--- a/azure/values-azure-primary.yaml
+++ b/azure/values-azure-primary.yaml
@@ -10,9 +10,8 @@ kubecostProductConfigs:
 kubecostModel:
   etlCloudAsset: false # set to true to enable kubecost to include out-of-cluster cloud resources (uses more memory)
 prometheus:
-  :
-  # kube-state-metrics:
-  #   enabled: false
+  kube-state-metrics:
+    enabled: false
   server:
     global:
       external_labels:

--- a/azure/values-azure-primary.yaml
+++ b/azure/values-azure-primary.yaml
@@ -13,6 +13,11 @@ kubecostModel:
   # emitKsmV1Metrics: true # emit all KSM metrics in KSM v1. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
   # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 prometheus:
+  # Note: Even though we are disabling our bundled version of kube-state-metrics, Kubecost still emits v1 metrics.
+  # Care will need to be taken in environments that already have KSM deployed.
+  # For more information, see: https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  kubeStateMetrics:
+    enabled: false
   kube-state-metrics:
     disabled: true
   server:

--- a/azure/values-azure-primary.yaml
+++ b/azure/values-azure-primary.yaml
@@ -9,6 +9,9 @@ kubecostProductConfigs:
   # serviceKeySecretName: azure-service-key
 kubecostModel:
   etlCloudAsset: false # set to true to enable kubecost to include out-of-cluster cloud resources (uses more memory)
+# kubecostMetrics:
+  # emitKsmV1Metrics: true # emit all KSM metrics in KSM v1. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 prometheus:
   kube-state-metrics:
     enabled: false

--- a/azure/values-azure-primary.yaml
+++ b/azure/values-azure-primary.yaml
@@ -14,7 +14,7 @@ kubecostModel:
   # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 prometheus:
   kube-state-metrics:
-    enabled: false
+    disabled: true
   server:
     global:
       external_labels:

--- a/azure/values-azure-secondary.yaml
+++ b/azure/values-azure-secondary.yaml
@@ -21,7 +21,7 @@ global:
     proxy: false
 prometheus:
   kube-state-metrics:
-    enabled: false
+    disabled: true
   server:
     global:
       external_labels:

--- a/azure/values-azure-secondary.yaml
+++ b/azure/values-azure-secondary.yaml
@@ -20,6 +20,11 @@ global:
     enabled: false
     proxy: false
 prometheus:
+  # Note: Even though we are disabling our bundled version of kube-state-metrics, Kubecost still emits v1 metrics.
+  # Care will need to be taken in environments that already have KSM deployed.
+  # For more information, see: https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  kubeStateMetrics:
+    enabled: false
   kube-state-metrics:
     disabled: true
   server:

--- a/azure/values-azure-secondary.yaml
+++ b/azure/values-azure-secondary.yaml
@@ -17,9 +17,8 @@ global:
     enabled: false
     proxy: false
 prometheus:
-  # disable KSM if there is an existing deployment
-  # kube-state-metrics:
-  #   enabled: false
+  kube-state-metrics:
+    enabled: false
   server:
     global:
       external_labels:

--- a/azure/values-azure-secondary.yaml
+++ b/azure/values-azure-secondary.yaml
@@ -12,6 +12,9 @@ kubecostModel:
   etl: false
   etlCloudAsset: false
   maxQueryConcurrency: 1
+# kubecostMetrics:
+  # emitKsmV1Metrics: true # emit all KSM metrics in KSM v1. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 global:
   grafana:
     enabled: false

--- a/gcp/values-google-primary.yaml
+++ b/gcp/values-google-primary.yaml
@@ -12,7 +12,7 @@ kubecostModel:
   # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 prometheus:
   kube-state-metrics:
-    enabled: false
+    disabled: true
   server:
     global:
       external_labels:

--- a/gcp/values-google-primary.yaml
+++ b/gcp/values-google-primary.yaml
@@ -11,6 +11,11 @@ kubecostModel:
   # emitKsmV1Metrics: true # emit all KSM metrics in KSM v1. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
   # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 prometheus:
+  # Note: Even though we are disabling our bundled version of kube-state-metrics, Kubecost still emits v1 metrics.
+  # Care will need to be taken in environments that already have KSM deployed.
+  # For more information, see: https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  kubeStateMetrics:
+    enabled: false
   kube-state-metrics:
     disabled: true
   server:

--- a/gcp/values-google-primary.yaml
+++ b/gcp/values-google-primary.yaml
@@ -7,6 +7,9 @@ kubecostProductConfigs:
   cloudIntegrationSecret: cloud-integration # only runs on primary cluster
 kubecostModel:
   etlCloudAsset: false # set to true to enable kubecost to include out-of-cluster cloud resources  (uses more memory)
+# kubecostMetrics:
+  # emitKsmV1Metrics: true # emit all KSM metrics in KSM v1. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 prometheus:
   kube-state-metrics:
     enabled: false

--- a/gcp/values-google-primary.yaml
+++ b/gcp/values-google-primary.yaml
@@ -8,9 +8,8 @@ kubecostProductConfigs:
 kubecostModel:
   etlCloudAsset: false # set to true to enable kubecost to include out-of-cluster cloud resources  (uses more memory)
 prometheus:
-  # disable KSM if there is an existing deployment
-  # kube-state-metrics:
-  #   enabled: false
+  kube-state-metrics:
+    enabled: false
   server:
     global:
       external_labels:

--- a/gcp/values-google-secondary.yaml
+++ b/gcp/values-google-secondary.yaml
@@ -15,10 +15,9 @@ global:
     enabled: false
     proxy: false
 prometheus:
+  kube-state-metrics:
+    enabled: false
   server:
-  # disable KSM if there is an existing deployment
-  # kube-state-metrics:
-  #   enabled: false
     global:
       external_labels:
         # cluster_id should be unique for all clusters and the same value as .kubecostProductConfigs.clusterName

--- a/gcp/values-google-secondary.yaml
+++ b/gcp/values-google-secondary.yaml
@@ -18,6 +18,11 @@ global:
     enabled: false
     proxy: false
 prometheus:
+  # Note: Even though we are disabling our bundled version of kube-state-metrics, Kubecost still emits v1 metrics.
+  # Care will need to be taken in environments that already have KSM deployed.
+  # For more information, see: https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  kubeStateMetrics:
+    enabled: false
   kube-state-metrics:
     disabled: true
   server:

--- a/gcp/values-google-secondary.yaml
+++ b/gcp/values-google-secondary.yaml
@@ -10,6 +10,9 @@ kubecostModel:
   etl: false
   etlCloudAsset: false
   maxQueryConcurrency: 1
+# kubecostMetrics:
+  # emitKsmV1Metrics: true # emit all KSM metrics in KSM v1. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
+  # emitKsmV1MetricsOnly: false # emit only the KSM metrics missing from KSM v2. Advanced users only. https://github.com/kubecost/docs/blob/main/ksm-metrics.md
 global:
   grafana:
     enabled: false

--- a/gcp/values-google-secondary.yaml
+++ b/gcp/values-google-secondary.yaml
@@ -19,7 +19,7 @@ global:
     proxy: false
 prometheus:
   kube-state-metrics:
-    enabled: false
+    disabled: true
   server:
     global:
       external_labels:


### PR DESCRIPTION
Seeing as Kubecost emits all KSM metrics by default, we should be able to disable the KSM pod.

Additionally, I added the values for modifying what KSM metrics we emit as it comes up on most POCs.