### PR TITLE
Terraform Directory w/ kubecost helm example

### DIFF
--- a/terraform/helm-kubecost/.terraform.lock.hcl
+++ b/terraform/helm-kubecost/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "2.8.0"
+  hashes = [
+    "h1:U0w0mUT0SwZCR0poGNSxGaZJKWcOiu4GerpGztYBiMM=",
+    "zh:1e42d1a04c07d4006844e477ca32b5f45b04f6525dbbbe00b6be6e6ec5a11c54",
+    "zh:2f87187cb48ccfb18d12e2c4332e7e822923b659e7339b954b7db78aff91529f",
+    "zh:391fe49b4d2dc07bc717248a3fc6952189cfc49c596c514ad72a29c9a9f9d575",
+    "zh:89272048e1e63f3edc3e83dfddd5a9fd4bd2a4ead104e67de1e14319294dedf1",
+    "zh:a5a057c3435a854389ce8a1d98a54aaa7cbab68aca7baa436a605897aa70ff7e",
+    "zh:b1098e53e1a8a3afcd325ecd0328662156b3d9c3d80948f19ba3a4eb870cee2b",
+    "zh:b676f949e8274a2b6c3fa41f5428ea597125579c7b93bb50bb73a5e295a7a447",
+    "zh:cdf7e9460f28c2dbfe49a79a5022bd0d474ff18120d340738aa35456ba77ebca",
+    "zh:e24b59b4ed1c593facbf8051ec58550917991e2e017f3085dac5fb902d9908cb",
+    "zh:e3b5e1f5543cac9d9031a028f1c1be4858fb80fae69f181f21e9465e366ebfa2",
+    "zh:e9fddc0bcdb28503078456f0088851d45451600d229975fd9990ee92c7489a10",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.16.1"
+  hashes = [
+    "h1:PO4Ye/+lu5hCaUEOtwNOldQYoA0dqL1bcBICIpdlcd8=",
+    "zh:06224975f5910d41e73b35a4d5079861da2c24f9353e3ebb015fbb3b3b996b1c",
+    "zh:2bc400a8d9fe7755cca27c2551564a9e2609cfadc77f526ef855114ee02d446f",
+    "zh:3a479014187af1d0aec3a1d3d9c09551b801956fe6dd29af1186dec86712731b",
+    "zh:73fb0a69f1abdb02858b6589f7fab6d989a0f422f7ad95ed662aaa84872d3473",
+    "zh:a33852cd382cbc8e06d3f6c018b468ad809d24d912d64722e037aed1f9bf39db",
+    "zh:b533ff2214dca90296b1d22eace7eaa7e3efe5a7ae9da66a112094abc932db4f",
+    "zh:ddf74d8bb1aeb01dc2c36ef40e2b283d32b2a96db73f6daaf179fa2f10949c80",
+    "zh:e720f3a15d34e795fa9ff90bc755e838ebb4aef894aa2a423fb16dfa6d6b0667",
+    "zh:e789ae70a658800cb0a19ef7e4e9b26b5a38a92b43d1f41d64fc8bb46539cefb",
+    "zh:e8aed7dc0bd8f843d607dee5f72640dbef6835a8b1c6ea12cea5b4ec53e463f7",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb3ac4f43c8b0dfc0b0103dd0f062ea72b3a34518d4c8808e3a44c9a3dd5f024",
+  ]
+}

--- a/terraform/helm-kubecost/README.md
+++ b/terraform/helm-kubecost/README.md
@@ -1,0 +1,25 @@
+# helm-kubecost
+
+## Overview
+
+This terraform was built as a basic example for using helm to deploy kubecost to a k8s cluster.
+
+## Usage
+
+1. You must first download the terraform client to run the terraform against your k8s cluster.  This terraform was original written and run with v1.3.7. You can find listings to the different versions of the terraform clients at the link below.
+
+https://releases.hashicorp.com/terraform/
+
+2. The terraform was written to utilize the local ~/.kube/config file by default.  Please make sure you are on referencing the corrent kube config file and are on the correct context before applying the terraform. If you are experienced with terraform, there are other options you can use to connect to the k8s cluster.  These changes can be made in main.tf the the helm provider block.  See linke below with additional information.
+
+https://registry.terraform.io/providers/hashicorp/helm/latest/docs#authentication
+
+3. The terraform uses the standard values.yaml shipped with the kubecost helm charts by default.  If you wish to use a local version of your values.yaml, you can define that in lines 15-19 of the helm.tf file.
+
+4. The terraform will deploy the latest kubecost helm charts by default.  If you wish to specify a specific chart version, you can do so in the terraform.tfvars file on lines 10 and 11 and uncommenting line 24 in the helm.tf file
+
+5. The terraform provides the option to deploy additional values configurations not defined in default/referenced values.yaml file.  If you wish to deploy additional values changes, you can do so on lines 26-31 on the helm.tf file.  You can use the same format to add as many values changes you like.
+
+## Notes
+
+Before running the terraform, please be sure to be authenticated and can connect to the k8s cluster.

--- a/terraform/helm-kubecost/helm.tf
+++ b/terraform/helm-kubecost/helm.tf
@@ -1,0 +1,32 @@
+#Create namespace
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = var.kubecost_namespace
+  }
+}
+
+# Create kubecost release and deploy cost-analyzer charts
+resource "helm_release" "kubecost" {
+  chart      = "cost-analyzer"
+  name       = "kubecost"
+  namespace  = var.kubecost_namespace
+  repository = var.kubecost_repo
+
+# Uncomment lines below to point at local copy of values.yaml file.  This terraform is setup by default to use kubecost packages values.yaml
+
+#  values = [
+#    "${file("values.yaml")}"
+#  ]
+
+
+# Uncomment line below if you wish to use a specific version.  Change the version in terraform.tfvars
+
+#  version    = var.kubecost_chart_version
+
+# Uncomment lines below to set additional helm values not defined in your values.yaml
+
+#    set {
+#    name  = "prometheus.server.persistentVolume.enabled"
+#    value = true
+#  }
+}

--- a/terraform/helm-kubecost/main.tf
+++ b/terraform/helm-kubecost/main.tf
@@ -1,0 +1,9 @@
+provider "helm" {
+  kubernetes {
+    config_path = pathexpand(var.kube_config)
+  }
+}
+
+provider "kubernetes" {
+  config_path = pathexpand(var.kube_config)
+}

--- a/terraform/helm-kubecost/outputs.tf
+++ b/terraform/helm-kubecost/outputs.tf
@@ -1,0 +1,9 @@
+output "kubecost-dashboard" {
+  value = <<EOT
+
+  To access the kubecost dashboard, run the command below and then visit http://localhost:9090/ in your web browser.
+  
+  kubectl port-forward --namespace kubecost deployment/kubecost-cost-analyzer 9090:9090
+  
+  EOT           
+}

--- a/terraform/helm-kubecost/terraform.tfvars
+++ b/terraform/helm-kubecost/terraform.tfvars
@@ -1,0 +1,11 @@
+# Uncomment line below if you want to change path to kube config file.
+# kube_config = "insert kube config path here"
+
+# Uncomment line below if you want to change the namespace kubecost is placed in.  We highly recommend not changing this value and leaving kubecost in the kubecost namespace
+# kubecost_namespace = "insert new namespace here"
+
+# Uncomment line below to point kubecost at local charts.  This terraform is setup by default to pull the charts from public repo. The path must include repo/chart
+# kubecost_repo = "insert local repo path here"
+
+# Uncomment line below to specify a spcific chart version
+# kubecost_chart_version = "1.99.0"

--- a/terraform/helm-kubecost/variables.tf
+++ b/terraform/helm-kubecost/variables.tf
@@ -1,0 +1,19 @@
+variable "kube_config" {
+  type    = string
+  default = "~/.kube/config"
+}
+
+variable "kubecost_namespace" {
+  type    = string
+  default = "kubecost"
+}
+
+variable "kubecost_repo" {
+  type = string
+  default = "https://kubecost.github.io/cost-analyzer/"
+}
+
+variable "kubecost_chart_version" {
+  type = string
+  default = "1.99.0"
+}


### PR DESCRIPTION
Description:
Adding a new terraform directory to the poc-common-configurations repo.  First addition to the terraform directory is kubecost-helm which is an example of how to use terraform/helm to install kubecost to an existing existing k8s cluster