### PR TITLE
First commit. Add instructions to integrate Kubecost with Datadog

### DIFF
--- a/datadog/Kubecostdashboard.json
+++ b/datadog/Kubecostdashboard.json
@@ -1,0 +1,774 @@
+{
+  "title": "Kubecost dashboard",
+  "description": "",
+  "widgets": [
+    {
+      "id": 2344982212878190,
+      "definition": {
+        "title": "Cluster Costs Overview",
+        "background_color": "vivid_green",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 6129707067870730,
+            "definition": {
+              "type": "image",
+              "url": "https://kubecost.awsworkshop.io/images/kubecost_logo.png",
+              "sizing": "contain",
+              "margin": "md",
+              "has_background": false,
+              "has_border": false,
+              "vertical_align": "center",
+              "horizontal_align": "center"
+            },
+            "layout": { "x": 0, "y": 0, "width": 12, "height": 1 }
+          },
+          {
+            "id": 6087428645000872,
+            "definition": {
+              "title": "Total Monthly Cost",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "name": "cpu1",
+                      "data_source": "metrics",
+                      "query": "sum:kubecost.kube.node.status.capacity.cpu.cores{$cluster}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "cpu2",
+                      "data_source": "metrics",
+                      "query": "avg:kubecost.node.cpu.hourly.cost{$cluster}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "cpu3",
+                      "data_source": "metrics",
+                      "query": "avg:kubecost.node.gpu.hourly.cost{$cluster}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "memory1",
+                      "data_source": "metrics",
+                      "query": "sum:kubecost.kube.node.status.capacity.memory.bytes{$cluster}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "memory2",
+                      "data_source": "metrics",
+                      "query": "avg:kubecost.node.ram.hourly.cost{$cluster}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "storage1",
+                      "data_source": "metrics",
+                      "query": "sum:kubecost.kube.persistentvolume.capacity.bytes{$cluster}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "storage2",
+                      "data_source": "metrics",
+                      "query": "avg:kubecost.pv.hourly.cost{$cluster}",
+                      "aggregator": "avg"
+                    }
+                  ],
+                  "conditional_formats": [
+                    {
+                      "comparator": ">",
+                      "value": 0,
+                      "palette": "white_on_green"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "formula": "(cpu1 * cpu2 * 730 + cpu3 * 730) + (memory1 / 1024 / 1024 / 1024 * memory2 * 730) + (storage1 * 730 * storage2 / 1024 / 1024 / 1024)"
+                    }
+                  ]
+                }
+              ],
+              "autoscale": false,
+              "custom_unit": "$",
+              "precision": 2,
+              "timeseries_background": { "type": "area" }
+            },
+            "layout": { "x": 0, "y": 1, "width": 6, "height": 2 }
+          },
+          {
+            "id": 3637404186302674,
+            "definition": {
+              "title": "Monthly Cost by Node",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_table",
+              "requests": [
+                {
+                  "queries": [
+                    {
+                      "name": "cpu3",
+                      "data_source": "metrics",
+                      "query": "avg:kubecost.node.gpu.hourly.cost{$cluster} by {node}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "cpu1",
+                      "data_source": "metrics",
+                      "query": "sum:kubecost.kube.node.status.capacity.cpu.cores{$cluster} by {node}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "cpu2",
+                      "data_source": "metrics",
+                      "query": "avg:kubecost.node.cpu.hourly.cost{$cluster}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "memory1",
+                      "data_source": "metrics",
+                      "query": "sum:kubecost.kube.node.status.capacity.memory.bytes{$cluster} by {node}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "memory2",
+                      "data_source": "metrics",
+                      "query": "avg:kubecost.node.ram.hourly.cost{$cluster}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "storage1",
+                      "data_source": "metrics",
+                      "query": "sum:kubecost.kube.persistentvolume.capacity.bytes{$cluster}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "storage2",
+                      "data_source": "metrics",
+                      "query": "avg:kubecost.pv.hourly.cost{$cluster}",
+                      "aggregator": "avg"
+                    }
+                  ],
+                  "formulas": [
+                    {
+                      "alias": "GPU cost",
+                      "conditional_formats": [
+                        {
+                          "comparator": ">",
+                          "palette": "black_on_light_red",
+                          "value": 0
+                        }
+                      ],
+                      "formula": "cpu3"
+                    },
+                    {
+                      "alias": "CPU cost ($)",
+                      "conditional_formats": [
+                        {
+                          "comparator": ">",
+                          "palette": "black_on_light_green",
+                          "value": 0
+                        }
+                      ],
+                      "formula": "cpu1 * cpu2 * 730"
+                    },
+                    {
+                      "alias": "Memory cost ($)",
+                      "conditional_formats": [
+                        {
+                          "comparator": ">",
+                          "palette": "black_on_light_yellow",
+                          "value": 0
+                        }
+                      ],
+                      "style": { "palette": "dog_classic" },
+                      "formula": "memory1 / 1024 / 1024 / 1024 * memory2 * 730"
+                    },
+                    {
+                      "alias": "Total cost ($)",
+                      "conditional_formats": [
+                        {
+                          "comparator": ">",
+                          "palette": "white_on_green",
+                          "value": 0
+                        }
+                      ],
+                      "formula": "(cpu1 * cpu2 * 730 + cpu3) + (memory1 / 1024 / 1024 / 1024 * memory2 * 730) + cpu3",
+                      "limit": { "count": 500, "order": "desc" }
+                    }
+                  ],
+                  "response_format": "scalar"
+                }
+              ],
+              "has_search_bar": "always"
+            },
+            "layout": { "x": 6, "y": 1, "width": 6, "height": 4 }
+          },
+          {
+            "id": 1774234409851898,
+            "definition": {
+              "title": "Monthly CPU Cost",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "name": "query1",
+                      "data_source": "metrics",
+                      "query": "sum:kubecost.kube.node.status.capacity.cpu.cores{$cluster}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "query2",
+                      "data_source": "metrics",
+                      "query": "avg:kubecost.node.cpu.hourly.cost{$cluster}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "query3",
+                      "data_source": "metrics",
+                      "query": "avg:kubecost.node.gpu.hourly.cost{$cluster}",
+                      "aggregator": "avg"
+                    }
+                  ],
+                  "formulas": [
+                    { "formula": "query1 * query2 * 730 + query3 * 730" }
+                  ],
+                  "conditional_formats": [
+                    {
+                      "comparator": ">",
+                      "value": 0,
+                      "palette": "black_on_light_green"
+                    }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "custom_unit": "$",
+              "precision": 2
+            },
+            "layout": { "x": 0, "y": 3, "width": 2, "height": 2 }
+          },
+          {
+            "id": 5741838588371966,
+            "definition": {
+              "title": "Monthly Memory Cost",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "name": "query1",
+                      "data_source": "metrics",
+                      "query": "sum:kubecost.kube.node.status.capacity.memory.bytes{$cluster}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "query2",
+                      "data_source": "metrics",
+                      "query": "avg:kubecost.node.ram.hourly.cost{$cluster}",
+                      "aggregator": "avg"
+                    }
+                  ],
+                  "conditional_formats": [
+                    {
+                      "comparator": ">",
+                      "value": 0,
+                      "palette": "black_on_light_green"
+                    }
+                  ],
+                  "formulas": [
+                    { "formula": "query1 / 1024 / 1024 / 1024 * query2 * 730" }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "custom_unit": "$",
+              "precision": 2,
+              "timeseries_background": { "type": "area" }
+            },
+            "layout": { "x": 2, "y": 3, "width": 2, "height": 2 }
+          },
+          {
+            "id": 8390578867091298,
+            "definition": {
+              "title": "Monthly Storage Cost",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "name": "query1",
+                      "data_source": "metrics",
+                      "query": "sum:kubecost.kube.persistentvolume.capacity.bytes{$cluster}",
+                      "aggregator": "avg"
+                    },
+                    {
+                      "name": "query2",
+                      "data_source": "metrics",
+                      "query": "avg:kubecost.pv.hourly.cost{$cluster}",
+                      "aggregator": "avg"
+                    }
+                  ],
+                  "conditional_formats": [
+                    {
+                      "comparator": ">",
+                      "value": 0,
+                      "palette": "black_on_light_green"
+                    }
+                  ],
+                  "formulas": [
+                    { "formula": "query1 * 730 * query2 / 1024 / 1024 / 1024" }
+                  ]
+                }
+              ],
+              "autoscale": true,
+              "custom_unit": "$",
+              "precision": 2,
+              "timeseries_background": { "type": "area" }
+            },
+            "layout": { "x": 4, "y": 3, "width": 2, "height": 2 }
+          },
+          {
+            "id": 7103466439959236,
+            "definition": {
+              "title": "Hourly Cost by Container",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "formulas": [
+                    {
+                      "formula": "(query1 * query2 / 1024 / 1024 / 1024) + query3 * query4",
+                      "limit": { "order": "desc" }
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "query": "sum:kubecost.container.memory.allocation.bytes{$cluster} by {container,namespace,instance}",
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "aggregator": "sum"
+                    },
+                    {
+                      "query": "sum:kubecost.node.ram.hourly.cost{$cluster}",
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "aggregator": "sum"
+                    },
+                    {
+                      "query": "sum:kubecost.container.cpu.allocation{$cluster} by {container,namespace,instance}",
+                      "data_source": "metrics",
+                      "name": "query3",
+                      "aggregator": "sum"
+                    },
+                    {
+                      "query": "sum:kubecost.node.cpu.hourly.cost{$cluster}",
+                      "data_source": "metrics",
+                      "name": "query4",
+                      "aggregator": "sum"
+                    }
+                  ],
+                  "style": { "palette": "datadog16" }
+                }
+              ],
+              "type": "sunburst",
+              "hide_total": false,
+              "legend": { "type": "table" }
+            },
+            "layout": { "x": 0, "y": 5, "width": 12, "height": 4 }
+          },
+          {
+            "id": 5309240946808430,
+            "definition": {
+              "title": "Hourly Cost by Namespace",
+              "title_size": "16",
+              "title_align": "left",
+              "requests": [
+                {
+                  "response_format": "scalar",
+                  "formulas": [
+                    {
+                      "formula": "(query1 * query2 / 1024 / 1024 / 1024) + query3 * query4",
+                      "limit": { "order": "desc" }
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "query": "sum:kubecost.container.memory.allocation.bytes{$cluster} by {namespace,instance}",
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "aggregator": "sum"
+                    },
+                    {
+                      "query": "sum:kubecost.node.ram.hourly.cost{$cluster}",
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "aggregator": "sum"
+                    },
+                    {
+                      "query": "sum:kubecost.container.cpu.allocation{$cluster} by {namespace,instance}",
+                      "data_source": "metrics",
+                      "name": "query3",
+                      "aggregator": "sum"
+                    },
+                    {
+                      "query": "sum:kubecost.node.cpu.hourly.cost{$cluster}",
+                      "data_source": "metrics",
+                      "name": "query4",
+                      "aggregator": "sum"
+                    }
+                  ],
+                  "style": { "palette": "classic" }
+                }
+              ],
+              "type": "sunburst",
+              "hide_total": false,
+              "legend": { "type": "table" }
+            },
+            "layout": { "x": 0, "y": 9, "width": 12, "height": 4 }
+          },
+          {
+            "id": 8660996379592338,
+            "definition": {
+              "title": "CPU Usage",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "(query1 / query2) * 100" }],
+                  "conditional_formats": [
+                    {
+                      "palette": "white_on_green",
+                      "value": 80,
+                      "comparator": "<"
+                    },
+                    {
+                      "palette": "white_on_yellow",
+                      "value": 90,
+                      "comparator": "<"
+                    },
+                    {
+                      "palette": "white_on_red",
+                      "value": 90,
+                      "comparator": ">"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "query": "sum:kubernetes.cpu.requests{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "aggregator": "last"
+                    },
+                    {
+                      "query": "sum:kubernetes_state.node.cpu_allocatable{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "aggregator": "last"
+                    }
+                  ]
+                }
+              ],
+              "autoscale": false,
+              "custom_unit": "%",
+              "precision": 2
+            },
+            "layout": { "x": 0, "y": 13, "width": 2, "height": 2 }
+          },
+          {
+            "id": 27112096702006,
+            "definition": {
+              "title": "Cluster CPU Capacity  ",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "horizontal",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    { "alias": "capacity", "formula": "query3" },
+                    { "alias": "allocatable", "formula": "query4" },
+                    { "alias": "requests", "formula": "query5" }
+                  ],
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "query": "sum:kubernetes_state.node.cpu_capacity{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query3"
+                    },
+                    {
+                      "query": "sum:kubernetes_state.node.cpu_allocatable{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query4"
+                    },
+                    {
+                      "query": "sum:kubernetes.cpu.requests{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query5"
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear",
+                "label": "",
+                "min": "auto",
+                "max": "auto"
+              },
+              "markers": []
+            },
+            "layout": { "x": 2, "y": 13, "width": 10, "height": 2 }
+          },
+          {
+            "id": 5238957675727826,
+            "definition": {
+              "title": "Memory Usage",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "(query1 / query2) * 100" }],
+                  "conditional_formats": [
+                    {
+                      "palette": "white_on_green",
+                      "value": 80,
+                      "comparator": "<"
+                    },
+                    {
+                      "palette": "white_on_red",
+                      "value": 90,
+                      "comparator": ">"
+                    },
+                    {
+                      "palette": "white_on_yellow",
+                      "value": 90,
+                      "comparator": "<"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "query": "sum:kubernetes.memory.requests{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "aggregator": "last"
+                    },
+                    {
+                      "query": "sum:kubernetes_state.node.memory_allocatable{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "aggregator": "last"
+                    }
+                  ]
+                }
+              ],
+              "autoscale": false,
+              "custom_unit": "%",
+              "precision": 2
+            },
+            "layout": { "x": 0, "y": 15, "width": 2, "height": 2 }
+          },
+          {
+            "id": 3000700704832776,
+            "definition": {
+              "title": "Cluster Memory Capacity ",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "horizontal",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    { "alias": "capacity", "formula": "query3" },
+                    { "alias": "allocatable", "formula": "query6" },
+                    { "alias": "requests", "formula": "query4" }
+                  ],
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "query": "sum:kubernetes_state.node.memory_capacity{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query3"
+                    },
+                    {
+                      "query": "sum:kubernetes_state.node.memory_allocatable{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query6"
+                    },
+                    {
+                      "query": "sum:kubernetes.memory.requests{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query4"
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear",
+                "label": "",
+                "min": "auto",
+                "max": "auto"
+              },
+              "markers": []
+            },
+            "layout": { "x": 2, "y": 15, "width": 10, "height": 2 }
+          },
+          {
+            "id": 7709953950820678,
+            "definition": {
+              "title": "Pod Utilization",
+              "title_size": "16",
+              "title_align": "left",
+              "type": "query_value",
+              "requests": [
+                {
+                  "formulas": [{ "formula": "(query1 / query2) * 100" }],
+                  "conditional_formats": [
+                    {
+                      "palette": "white_on_green",
+                      "value": 80,
+                      "comparator": "<"
+                    },
+                    {
+                      "palette": "white_on_yellow",
+                      "value": 90,
+                      "comparator": "<"
+                    },
+                    {
+                      "palette": "white_on_red",
+                      "value": 90,
+                      "comparator": ">"
+                    }
+                  ],
+                  "response_format": "scalar",
+                  "queries": [
+                    {
+                      "query": "sum:kubernetes.pods.running{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "aggregator": "last"
+                    },
+                    {
+                      "query": "sum:kubernetes_state.node.pods_capacity{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "aggregator": "last"
+                    }
+                  ]
+                }
+              ],
+              "custom_unit": "%",
+              "precision": 2
+            },
+            "layout": { "x": 0, "y": 17, "width": 2, "height": 2 }
+          },
+          {
+            "id": 1645568509757470,
+            "definition": {
+              "title": "Cluster Pod Utilization",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "horizontal",
+              "legend_columns": ["avg", "min", "max", "value", "sum"],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    { "formula": "query1", "alias": "capacity" },
+                    { "formula": "query2", "alias": "allocatable" },
+                    { "formula": "query3", "alias": "running" }
+                  ],
+                  "response_format": "timeseries",
+                  "queries": [
+                    {
+                      "query": "sum:kubernetes_state.node.pods_capacity{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query1"
+                    },
+                    {
+                      "query": "sum:kubernetes_state.node.pods_allocatable{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query2"
+                    },
+                    {
+                      "query": "sum:kubernetes.pods.running{$cluster,$scope}",
+                      "data_source": "metrics",
+                      "name": "query3"
+                    }
+                  ],
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear",
+                "label": "",
+                "min": "auto",
+                "max": "auto"
+              },
+              "markers": []
+            },
+            "layout": { "x": 2, "y": 17, "width": 10, "height": 2 }
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 0, "width": 12, "height": 20 }
+    }
+  ],
+  "template_variables": [
+    { "name": "scope", "available_values": [], "default": "*" },
+    {
+      "name": "cluster",
+      "prefix": "kube_cluster_name",
+      "available_values": [],
+      "default": "*"
+    }
+  ],
+  "layout_type": "ordered",
+  "notify_list": [],
+  "reflow_type": "fixed",
+  "id": "8n2-ivb-eag"
+}

--- a/datadog/Kubecostdashboard.json
+++ b/datadog/Kubecostdashboard.json
@@ -28,9 +28,10 @@
           {
             "id": 6087428645000872,
             "definition": {
-              "title": "Total Monthly Cost",
+              "title": "Total Monthly Cost (onDemand)",
               "title_size": "16",
               "title_align": "left",
+              "time": {},
               "type": "query_value",
               "requests": [
                 {
@@ -103,9 +104,10 @@
           {
             "id": 3637404186302674,
             "definition": {
-              "title": "Monthly Cost by Node",
+              "title": "Monthly Cost by Node (onDemand)",
               "title_size": "16",
               "title_align": "left",
+              "time": {},
               "type": "query_table",
               "requests": [
                 {
@@ -345,9 +347,10 @@
           {
             "id": 7103466439959236,
             "definition": {
-              "title": "Hourly Cost by Container",
+              "title": "Hourly Cost by Container (onDemand)",
               "title_size": "16",
               "title_align": "left",
+              "time": {},
               "requests": [
                 {
                   "response_format": "scalar",
@@ -395,9 +398,10 @@
           {
             "id": 5309240946808430,
             "definition": {
-              "title": "Hourly Cost by Namespace",
+              "title": "Hourly Cost by Namespace (onDemand)",
               "title_size": "16",
               "title_align": "left",
+              "time": {},
               "requests": [
                 {
                   "response_format": "scalar",

--- a/datadog/README.MD
+++ b/datadog/README.MD
@@ -1,9 +1,13 @@
 # Kubecost with Datadog integration
 
 ## Overview
+This repository is designed to give you a solution to integrate Kubecost with Datadog. By default, Kubecost will emit cost allocation metrics (unaggregated, unreconciled) in a Prometheus-compatible format with cloud providers) via `/metrics` endpoint. This solution installs Kubecost with additional annotations in cost-model pods, which allows the Datadog agent to look into the `/metrics` endpoint, map Prometheus-compatible metrics to the Datadog-compatible metrics, then push the metrics to your Datadog account. 
+---
+## Caveats
 
-This repository is designed to give you a solution to integrate Kubecost with Datadog. By default, Kubecost will emit cost allocation metrics (unaggregrated, unreconciled) in a Prometheus compatible format with cloud providers) via `/metrics` endpoint. This solution installs Kubecost with additional annotations in cost-model pods, which allows Datadog agent to look into the `/metrics` endpoint, map prometheus compatible metrics to the Datadog compatible metrics, then push the metrics to your Datadog account. 
+Note that the only method to get accurate costs (reconciled with cloud provider billing) is to use the Kubecost API. Kubecost's `/metrics` endpoint contains real-time metrics that can only estimate costs using custom pricing or onDemand cloud provider rates.
 
+The primary purpose of the dashboards provided is to allow visibility into the metrics used by Kubecost to create the cost-model.
 ---
 ## Usage
 
@@ -13,11 +17,11 @@ This repository is designed to give you a solution to integrate Kubecost with Da
 - Datadog permissions to create dashboards
 - Permission to access and deploy new workload on the Kubernetes cluster.
 - kubectl, helm CLI, wget are installed.
----
+
 ### Instructions
 #### Install Datadog agent:
 
-You can install Datadog agent to start monitoring your Kubernetes cluster using your Datadog API key. In this set up, you need to enable these flags to allow Datadog agent collect the metrics from Kubecost's cost-model container: `datadog. prometheusScrape.enabled='true'` & `datadog. prometheusScrape.serviceEndpoints=true'`. Using the following commands to install Datadog agent 
+You can install the Datadog agent to start monitoring your Kubernetes cluster using your Datadog API key. In this setup, you need to enable these flags to allow the Datadog agent to collect the metrics from Kubecost's cost-model container: `datadog. prometheusScrape.enabled='true'` & `datadog. prometheusScrape.serviceEndpoints=true'`. Using the following commands to install the Datadog agent 
 
 ```bash
 export DATADOG_API_KEY="<YOUR_API_KEY>"
@@ -28,7 +32,7 @@ datadog. prometheusScrape.serviceEndpoints=‘true’
 
 #### Install Kubecost
 
-*Step 1*: download `datadog-values.yaml` from this repository. This is the custom config that includes additional annotations allows Datadog agent to extract, transform and load raw cost allocation metrics into your Datadog account.
+*Step 1*: download `datadog-values.yaml` from this repository. This file contains the custom configs and additional annotations allowing Datadog agent to extract, transform and load raw cost allocation metrics into your Datadog account.
 
 ```bash
 wget https://raw.githubusercontent.com/kubecost/poc-common-configurations/main/datadog/datadog-values.yaml
@@ -43,11 +47,11 @@ helm upgrade --install kubecost --namespace kubecost --create-namespace \
   --set kubecostToken="aGVsbUBrdWJlY29zdC5jb20=xm343yadf98"
 ```
 
-Allow 3-5 minutes to have Kubecost installation completed and the metrics are pushed into your Datadog account. You can verify if the metrics are available by using [Datadog Metrics explorer](https://docs.datadoghq.com/metrics/explorer/) and looking for metrics starting with `kubecost.*`
+Allow 3-5 minutes to have the Kubecost installation completed, and the metrics are pushed into your Datadog account. You can verify if the metrics are available by using [Datadog Metrics explorer](https://docs.datadoghq.com/metrics/explorer/) and looking for metrics starting with `kubecost.*`
 
 #### Import Kubecost Dashboard
 
-Once you can verify Kubecost metrics are pushed into your Datadog account successfully, you can download our example Datadog's dashboard `Kubecostdashboard.json` and import it into your Datadog account to visualize the cost allocation data.
+Once you can successfully verify that Kubecost metrics are pushed into your Datadog account, you can download our example Datadog's dashboard `Kubecostdashboard.json` and import it into your Datadog account to visualize the cost allocation data.
 
 ```bash
 wget https://raw.githubusercontent.com/kubecost/poc-common-configurations/main/datadog/Kubecostdashboard.json

--- a/datadog/README.MD
+++ b/datadog/README.MD
@@ -1,0 +1,56 @@
+# Kubecost with Datadog integration
+
+## Overview
+
+This repository is designed to give you a solution to integrate Kubecost with Datadog. By default, Kubecost will emit cost allocation metrics (unaggregrated, unreconciled) in a Prometheus compatible format with cloud providers) via `/metrics` endpoint. This solution installs Kubecost with additional annotations in cost-model pods, which allows Datadog agent to look into the `/metrics` endpoint, map prometheus compatible metrics to the Datadog compatible metrics, then push the metrics to your Datadog account. 
+
+---
+## Usage
+
+### Prerequisites
+- Existing Datadog account.
+- Datadog API key to install the Datadog agent.
+- Datadog permissions to create dashboards
+- Permission to access and deploy new workload on the Kubernetes cluster.
+- kubectl, helm CLI, wget are installed.
+---
+### Instructions
+#### Install Datadog agent:
+
+You can install Datadog agent to start monitoring your Kubernetes cluster using your Datadog API key. In this set up, you need to enable these flags to allow Datadog agent collect the metrics from Kubecost's cost-model container: `datadog. prometheusScrape.enabled='true'` & `datadog. prometheusScrape.serviceEndpoints=true'`. Using the following commands to install Datadog agent 
+
+```bash
+export DATADOG_API_KEY="<YOUR_API_KEY>"
+helm upgrade -i datadog-agent --set datadog.site='us5.datadoghq.com' --set datadog.apiKey=$DATADOG_API_KEY datadog/datadog \
+datadog. prometheusScrape.enabled=‘true’ \
+datadog. prometheusScrape.serviceEndpoints=‘true’
+```
+
+#### Install Kubecost
+
+*Step 1*: download `datadog-values.yaml` from this repository. This is the custom config that includes additional annotations allows Datadog agent to extract, transform and load raw cost allocation metrics into your Datadog account.
+
+```bash
+wget https://raw.githubusercontent.com/kubecost/poc-common-configurations/main/datadog/datadog-values.yaml
+```
+
+*Step 2* Install Kubecost using the following command:
+
+```bash
+helm upgrade --install kubecost --namespace kubecost --create-namespace \
+  --repo https://kubecost.github.io/cost-analyzer/ cost-analyzer \
+  -f datadog-values.yaml
+  --set kubecostToken="aGVsbUBrdWJlY29zdC5jb20=xm343yadf98"
+```
+
+Allow 3-5 minutes to have Kubecost installation completed and the metrics are pushed into your Datadog account. You can verify if the metrics are available by using [Datadog Metrics explorer](https://docs.datadoghq.com/metrics/explorer/) and looking for metrics starting with `kubecost.*`
+
+#### Import Kubecost Dashboard
+
+Once you can verify Kubecost metrics are pushed into your Datadog account successfully, you can download our example Datadog's dashboard `Kubecostdashboard.json` and import it into your Datadog account to visualize the cost allocation data.
+
+```bash
+wget https://raw.githubusercontent.com/kubecost/poc-common-configurations/main/datadog/Kubecostdashboard.json
+```
+
+Check this [Datadog documentation ](https://docs.datadoghq.com/dashboards/#copy-import-or-export-dashboard-json)to learn how to import dashboard JSON.

--- a/datadog/datadog-values.yaml
+++ b/datadog/datadog-values.yaml
@@ -1,0 +1,91 @@
+global:
+  podAnnotations:
+    ad.datadoghq.com/cost-model.checks: |
+      {
+        "openmetrics": {
+          "instances": [
+            {
+              "openmetrics_endpoint": "http://%%host%%:9003/metrics",
+              "namespace": "kubecost",
+              "metrics": [
+                  {"node_cpu_hourly_cost": "node.cpu.hourly.cost"},
+                  {"node_gpu_hourly_cost": "node.gpu.hourly.cost"},
+                  {"node_ram_hourly_cost": "node.ram.hourly.cost"},
+                  {"node_total_hourly_cost": "node.total.hourly.cost"},
+                  {"kubecost_load_balancer_cost": "kubecost.load.balancer.cost"},
+                  {"kubecost_cluster_management_cost": "kubecost.cluster.management.cost"},
+                  {"pv_hourly_cost": "pv.hourly.cost"},
+                  {"node_gpu_count": "node.gpu.count"},
+                  {"container_cpu_allocation": "container.cpu.allocation"},
+                  {"container_gpu_allocation": "container.gpu.allocation"},
+                  {"container_memory_allocation_bytes": "container.memory.allocation.bytes"},
+                  {"pod_pvc_allocation": "pod.pvc.allocation"},
+                  {"kubecost_node_is_spot": "kubecost.node.is.spot"},
+                  {"kubecost_network_zone_egress_cost": "kubecost.network.zone.egress.cost"},
+                  {"kubecost_network_region_egress_cost": "kubecost.network.region.egress.cost"},
+                  {"kubecost_network_internet_egress_cost": "kubecost.network.internet.egress.cost"},
+                  {"service_selector_labels": "service.selector.labels"},
+                  {"deployment_match_labels": "deployment.match.labels"},
+                  {"statefulSet_match_labels": "statefulSet.match.labels"},
+                  {"kubecost_cluster_memory_working_set_bytes": "kubecost.cluster.memory.working.set.bytes"},
+                  {"kube_deployment_spec_replicas": "kube.deployment.spec.replicas"},
+                  {"kube_deployment_status_replicas_available": "kube.deployment.status.replicas.available"},
+                  {"kube_job_status_failed": "kube.job.status.failed"},
+                  {"kube_namespace_annotations": "kube.namespace.annotations"},
+                  {"kube_namespace_labels": "kube.namespace.labels"},
+                  {"kube_node_labels": "kube.node.labels"},
+                  {"kube_node_status_allocatable": "kube.node.status.allocatable"},
+                  {"kube_node_status_allocatable_cpu_cores": "kube.node.status.allocatable.cpu.cores"},
+                  {"kube_node_status_allocatable_memory_bytes": "kube.node.status.allocatable.memory.bytes"},
+                  {"kube_node_status_capacity": "kube.node.status.capacity"},
+                  {"kube_node_status_capacity_cpu_cores": "kube.node.status.capacity.cpu.cores"},
+                  {"kube_node_status_capacity_memory_bytes": "kube.node.status.capacity.memory.bytes"},
+                  {"kube_node_status_condition": "kube.node.status.condition"},
+                  {"kube_persistentvolume_capacity_bytes": "kube.persistentvolume.capacity.bytes"},
+                  {"kube_persistentvolume_status_phase": "kube.persistentvolume.status.phase"},
+                  {"kube_persistentvolumeclaim_info": "kube.persistentvolumeclaim.info"},
+                  {"kube_persistentvolumeclaim_resource_requests_storage_bytes": "kube.persistentvolumeclaim.resource.requests.storage.bytes"},
+                  {"kube_pod_annotations": "kube.pod.annotations"},
+                  {"kube_pod_container_resource_limits": "kube.pod.container.resource.limits"},
+                  {"kube_pod_container_resource_limits_cpu_cores": "kube.pod.container.resource.limits.cpu.cores"},
+                  {"kube_pod_container_resource_limits_memory_bytes": "kube.pod.container.resource.limits.memory.bytes"},
+                  {"kube_pod_container_resource_requests": "kube.pod.container.resource.requests"},
+                  {"kube_pod_container_status_restarts_total": "kube.pod.container.status.restarts.total"},
+                  {"kube_pod_container_status_running": "kube.pod.container.status.running"},
+                  {"kube_pod_container_status_terminated_reason": "kube.pod.container.status.terminated.reason"},
+                  {"kube_pod_labels": "kube.pod.labels"},
+                  {"kube_pod_owner": "kube.pod.owner"},
+                  {"kube_pod_status_phase": "kube.pod.status.phase"},
+                  {"kube_replicaset_owner": "kube.replicaset.owner"}
+                ]
+            }
+          ]
+        }
+      }
+
+networkCosts:
+  # For existing Prometheus Installs, annotates the Service which generates Endpoints for each of the network-costs pods.
+  # The Service is annotated with prometheus.io/scrape: "true" to automatically get picked up by the prometheus config.
+  # NOTE: Setting this option to true and leaving the above extraScrapeConfig "job_name: kubecost-networking" configured will cause the
+  # NOTE: pods to be scraped twice.
+  # NOTE: set prometheusScrape to true when you enable networkCost and want Datadog agent to collect corresponding networkCost metrics
+  # prometheusScrape: true
+
+  # Port will set both the containerPort and hostPort to this value.
+  # These must be identical due to network-costs being run on hostNetwork
+  port: 3001
+
+# Note: Un-comment the below section when networkCosts.prometheusScrape is enabled
+# prometheus:
+#   extraScrapeConfigs: |
+#     - job_name: kubecost
+#       honor_labels: true
+#       scrape_interval: 1m
+#       scrape_timeout: 60s
+#       metrics_path: /metrics
+#       scheme: http
+#       dns_sd_configs:
+#       - names:
+#         - {{ template "cost-analyzer.serviceName" . }}
+#         type: 'A'
+#         port: 9003


### PR DESCRIPTION
First commit. Add instructions to integrate Kubecost with Datadog.

This repository is designed to give you a solution to integrate Kubecost with Datadog. By default, Kubecost will emit cost allocation metrics (unaggregrated, unreconciled) in a Prometheus compatible format with cloud providers) via `/metrics` endpoint. This solution installs Kubecost with additional annotations in cost-model pods, which allows Datadog agent to look into the `/metrics` endpoint, map prometheus compatible metrics to the Datadog compatible metrics, then push the metrics to your Datadog account. 