### PR TITLE
Create irsa-iam-role-trust-policy-for-default-service-account

### DIFF
--- a/aws/iam-policies/irsa-iam-role-trust-policy-for-default-service-account
+++ b/aws/iam-policies/irsa-iam-role-trust-policy-for-default-service-account
@@ -1,0 +1,18 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::111122223333:oidc-provider/oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:sub": "system:serviceaccount:kubecost:kubecost-cost-analyzer",
+                    "oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:aud": "sts.amazonaws.com"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Adding generic trust policy for kubecost default service account used for IRSA setup.