### PR TITLE
Enhancements to FluxCD Configurations for Kubecost Actions and Carbon Costs

### DIFF
--- a/fluxcd/federated-etl-flux/README.md
+++ b/fluxcd/federated-etl-flux/README.md
@@ -85,6 +85,52 @@ https://docs.kubecost.com/install-and-configure/install/cloud-integration/multi-
 
 Once you have created the required secret, uncomment `kubecostProductConfigs.cloudIntegrationSecret` and populate the secret in `helmrelease-flux-primary.yaml` and apply the changes.
 
+## Kubecost Additional Plugins
+
+This section introduces additional plugins that extend the functionality of Kubecost, focusing on Kubecost Actions and Carbon Costs. These plugins provide more granular insights and control over your cloud spending and environmental impact.
+
+### Carbon Costs
+
+The Carbon Costs plugin adds a unique metric to both the Allocation and Assets dashboards within Kubecost. This metric, measured in kilograms of CO2 equivalent (KG CO2e), follows the Environmental Protection Agency (EPA)'s definition:
+
+> **Carbon dioxide equivalent (CO2e)** is the measure used to compare the emissions from various greenhouse gases based on their global warming potential (GWP). The CO2e for any gas is calculated by multiplying the tons of the gas by the associated GWP. \(CO2e = Metric Tons x GWP of the gas\).
+
+Kubecost leverages carbon coefficient data sourced from the Cloud Carbon Footprint initiative, attributing estimated carbon costs to various assets such as disk, node, and network resources, based on their operational runtime. These costs are subsequently allocated across different resources to provide a comprehensive view of environmental impact. For deeper insights into the coefficients' methodology, refer to the [Cloud Carbon Footprint's methodology page](https://www.cloudcarbonfootprint.org/docs/methodology).
+
+
+### Kubecost Actions
+
+Kubecost Actions is a powerful feature that allows you to create and manage automated savings actions directly within your Kubecost environment. Actions enable you to optimize cost management through a variety of strategies such as cluster turndown, request sizing, and namespace turndown, among others.
+
+#### Enabling Kubecost Actions
+To utilize Kubecost Actions, you first need to enable the Cluster Controller, which provides Kubecost administrative access to perform the actions. Note that this feature should be used with caution, as it allows write access to your cluster and can perform irreversible actions. Always ensure you have a backup before enabling.
+
+#### Action Capabilities
+- **Cluster Turndown:** Schedule the spin-down of clusters during idle times to save costs.
+- **Request Sizing:** Automatically right-size container requests to prevent over-provisioning.
+- **Namespace Turndown:** Manage and delete idle workloads to maintain efficiency in resource usage.
+
+#### Creating an Action
+In the Actions page, you can create a new action or manage existing ones. Choose from predefined actions like cluster turndown or request sizing, and configure them according to your needs. For experimental features like Guided Sizing and Cluster Sizing, enable them in the settings under 'Enable experimental features'.
+
+For a complete guide on how to enable and manage Kubecost Actions, including detailed configurations and recommendations, please visit the official documentation page: [Kubecost Actions Documentation](https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/savings/savings-actions#enabling-kubecost-actions).
+
+
+## Plugin Configuration in `helmrelease-plugins.yaml`
+
+To enable the Carbon Costs and Kubecost Actions features, there is a seperate template file called `helmrelease-plugins.yaml` , where we have outlined all of the configs that you can add to your release yaml. Note that , all of the configs go into your primary cluster's helm release.
+
+### Configuring Plugins on Your Primary Cluster
+
+All plugin configurations, including Carbon Costs and the various Kubecost Actions (Cluster Turndown, Namespace Turndown, Cluster Sizing), should be conducted on your primary cluster. The `helmrelease-plugins.yaml` file has been meticulously crafted to provide detailed settings for each action, facilitating significant infrastructure cost savings.
+
+It's important to ensure that the plugin configurations templates are correctly implemented in the `helmrelease-plugins.yaml` to enable these features fully. 
+
+For more guidance on configuring the `helmrelease-plugins.yaml` file for different Kubecost actions and ensuring optimal savings. Each section is tailored to help you efficiently configure and manage the respective features to maximize your infrastructure's cost-efficiency.
+
+
+
+
 ### Debugging Steps
 
 If you encounter issues during the installation process, follow these debugging steps to diagnose and resolve problems:

--- a/fluxcd/federated-etl-flux/README.md
+++ b/fluxcd/federated-etl-flux/README.md
@@ -100,7 +100,7 @@ Kubecost leverages carbon coefficient data sourced from the Cloud Carbon Footpri
 
 ### Kubecost Actions
 
-Kubecost Actions is a powerful feature that allows you to create and manage automated savings actions directly within your Kubecost environment. Actions enable you to optimize cost management through a variety of strategies such as cluster turndown, request sizing, and namespace turndown, among others.
+[Kubecost Actions](https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/savings/savings-actions) is a powerful feature that allows you to create and manage automated savings actions directly within your Kubecost environment. Actions enable you to optimize cost management through a variety of strategies such as cluster turndown, request sizing, and namespace turndown, among others.
 
 #### Enabling Kubecost Actions
 To utilize Kubecost Actions, you first need to enable the Cluster Controller, which provides Kubecost administrative access to perform the actions. Note that this feature should be used with caution, as it allows write access to your cluster and can perform irreversible actions. Always ensure you have a backup before enabling.

--- a/fluxcd/federated-etl-flux/README.md
+++ b/fluxcd/federated-etl-flux/README.md
@@ -91,7 +91,7 @@ This section introduces additional plugins that extend the functionality of Kube
 
 ### Carbon Costs
 
-The Carbon Costs plugin adds a unique metric to both the Allocation and Assets dashboards within Kubecost. This metric, measured in kilograms of CO2 equivalent (KG CO2e), follows the Environmental Protection Agency (EPA)'s definition:
+The Carbon Costs plugin (also see: [official docs](https://docs.kubecost.com/using-kubecost/carbon-costs)) adds a unique metric to both the Allocation and Assets dashboards within Kubecost. This metric, measured in kilograms of CO2 equivalent (KG CO2e), follows the Environmental Protection Agency (EPA)'s definition:
 
 > **Carbon dioxide equivalent (CO2e)** is the measure used to compare the emissions from various greenhouse gases based on their global warming potential (GWP). The CO2e for any gas is calculated by multiplying the tons of the gas by the associated GWP. \(CO2e = Metric Tons x GWP of the gas\).
 

--- a/fluxcd/federated-etl-flux/helmrelease-plugins.yaml
+++ b/fluxcd/federated-etl-flux/helmrelease-plugins.yaml
@@ -1,0 +1,253 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kubecost # Replace with the release name
+  namespace: flux-system # Replace with the namespace
+spec:
+  interval: 5m
+  targetNamespace: kubecost # Replace with the target namespace
+  chart:
+    spec:
+      chart: cost-analyzer
+      version: '>=2.0.0 <2.2.0'
+      sourceRef:
+        kind: HelmRepository
+        name: kubecost-charts # Replace with the Helm repository name
+        namespace: flux-system # Namespace for the Helm repository
+      interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      remediateLastFailure: True
+  values:
+    kubecostAggregator:
+      replicas: 1
+      deployMethod: statefulset
+    kubecostProductConfigs:
+      productKey:
+        enabled: true
+        key: "{{ .Values.kubecostProductConfigs.productKey }}" # Replace with your product key
+      cloudIntegrationSecret: "{{ .Values.kubecostProductConfigs.cloudIntegrationSecret }}" # Replace with your cloud integration secret
+      clusterName: "{{ .Values.clusterName }}" # Replace with your cluster name
+      # Enables Kubecost beta carbon estimation endpoints /assets/carbon and /allocations/carbon
+      carbonEstimates:
+        enabled: true
+      labelMappingConfigs:
+        enabled: true
+        owner_label: "{{ .Values.labelMappingConfigs.owner_label }}" # Define your labels
+        team_label: "{{ .Values.labelMappingConfigs.team_label }}"
+        department_label: "{{ .Values.labelMappingConfigs.department_label }}"
+        product_label: "{{ .Values.labelMappingConfigs.product_label }}"
+        environment_label: "{{ .Values.labelMappingConfigs.environment_label }}"
+    prometheus:
+      server:
+        global:
+          external_labels:
+            cluster_id: "{{ .Values.clusterId }}" # Replace with your cluster ID
+    global:
+      prometheus:
+        enabled: false
+      thanos:
+        enabled: false
+      grafana:
+        enabled: false
+        domainName: "{{ .Values.global.grafana.domainName }}" # Replace with your Grafana domain name
+      podAnnotations:
+        iam.amazonaws.com/role: "{{ .Values.global.podAnnotations.iamRole }}" # Replace with your IAM role
+      securityContext:
+        seccompProfile: null
+        runAsNonRoot: false
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+      hosts:
+      - "{{ .Values.ingress.host }}" # Replace with your ingress host
+    initChownDataImage: "{{ .Values.initChownDataImage }}" # Replace with your init chown data image
+    kubecostFrontend:
+      enabled: true
+      image: "gcr.io/kubecost1/frontend"
+      imagePullPolicy: Always
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 1Gi
+       # set to true to set all upstreams to use <service>.<namespace>.svc.cluster.local instead of just <service>.<namespace>
+      useDefaultFqdn: false
+    #  api:
+    #    fqdn: kubecost-api.kubecost.svc.cluster.local:9001
+    #  model:
+    #    fqdn: kubecost-model.kubecost.svc.cluster.local:9003
+    #  forecasting:
+    #    fqdn: kubecost-forcasting.kubecost.svc.cluster.local:5000
+    #  aggregator:
+    #    fqdn: kubecost-aggregator.kubecost.svc.cluster.local:9004
+    #  cloudCost:
+    #    fqdn: kubecost-cloud-cost.kubecost.svc.cluster.local:9005
+    #  multiClusterDiagnostics:
+    #    fqdn: kubecost-multi-diag.kubecost.svc.cluster.local:9007
+    #  clusterController:
+    #    fqdn: cluster-controller.kubecost.svc.cluster.local:9731
+      readinessProbe:
+        enabled: true
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        failureThreshold: 200
+      livenessProbe:
+        enabled: true
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        failureThreshold: 200
+    kubecostModel:
+      containerStatsEnabled: true
+      resources:
+        limits:
+          cpu: 6000m
+          memory: 64Gi
+      etlBucketConfigSecret: "{{ .Values.kubecostModel.etlBucketConfigSecret }}" # Replace with your ETL bucket config secret
+      federatedStorageConfigSecret: "{{ .Values.kubecostModel.federatedStorageConfigSecret }}" # Replace with your federated storage config secret
+      etlAssetReconciliationEnabled: true
+    networkCosts:
+      enabled: true
+      config:
+        services:
+          # google-cloud-services: when set to true, enables labeling traffic metrics with google cloud
+          # service endpoints
+          google-cloud-services: false
+          # amazon-web-services: when set to true, enables labeling traffic metrics with amazon web service
+          # endpoints.
+          amazon-web-services: false
+          # azure-cloud-services: when set to true, enables labeling traffic metrics with azure cloud service
+          # endpoints
+          azure-cloud-services: false
+    reporting:
+      logCollection: false
+      productAnalytics: false
+      errorReporting: false
+      valuesReporting: false
+    serviceMonitor:
+      enabled: true
+    prometheusRule:
+      enabled: true
+    supportNFS: true
+    
+    
+    # Kubecost Cluster Controller for Right Sizing and Cluster Turndown
+    clusterController:
+      enabled: false
+      image:
+        repository: gcr.io/kubecost1/cluster-controller
+        tag: v0.16.0
+      imagePullPolicy: Always
+      ## PriorityClassName
+      ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+      priorityClassName: ""
+      # Set custom tolerations for the cluster controller.
+      tolerations: []
+      actionConfigs:
+        # this configures the Kubecost Cluster Turndown action
+        # for more details, see documentation at https://github.com/kubecost/cluster-turndown/tree/develop?tab=readme-ov-file#setting-a-turndown-schedule
+        clusterTurndown: []
+          # - name: my-schedule
+          #   start: "2024-02-09T00:00:00Z"
+          #   end: "2024-02-09T12:00:00Z"
+          #   repeat: daily
+          # - name: my-schedule2
+          #   start: "2024-02-09T00:00:00Z"
+          #   end: "2024-02-09T01:00:00Z"
+          #   repeat: weekly
+        # this configures the Kubecost Namespace Turndown action
+        # for more details, see documentation at https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/savings/savings-actions#namespace-turndown
+        namespaceTurndown:
+          # - name: my-ns-turndown-action
+          #   dryRun: false
+          #   schedule: "0 0 * * *"
+          #   type: Scheduled
+          #   targetObjs:
+          #     - namespace
+          #   keepPatterns:
+          #     - ignorednamespace
+          #   keepLabels:
+          #     turndown: ignore
+          #   params:
+          #     minNamespaceAge: 4h
+        # this configures the Kubecost Cluster Sizing action
+        # for more details, see documentation at https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/savings/savings-actions#cluster-sizing
+        clusterRightsize:
+            # startTime: '2024-01-02T15:04:05Z'
+            # frequencyMinutes: 1440
+            # lastCompleted: ''
+            # recommendationParams:
+            #   window: 48h
+            #   architecture: ''
+            #   targetUtilization: 0.8
+            #   minNodeCount: 1
+            #   allowSharedCore: false
+            # allowCostIncrease: false
+            # recommendationType: ''
+        # This configures the Kubecost Continuous Request Sizing Action
+        #
+        # Using this configuration overrides annotation-based configuration of
+        # Continuous Request Sizing. Annotation configuration will be ignored while
+        # this configuration method is present in the cluster.
+        #
+        # For more details, see documentation at https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/savings/savings-actions#automated-request-sizing
+        containerRightsize:
+          # Workloads can be selected by an _exact_ key (namespace, controllerKind,
+          # controllerName). This will only match a single controller. The cluster
+          # ID is current irrelevant because Cluster Controller can only modify
+          # workloads within the cluster it is running in.
+          #  workloads:
+          #   - clusterID: cluster-one
+          #     namespace: my-namespace
+          #     controllerKind: deployment
+          #     controllerName: my-controller
+          # An alternative to exact key selection is filter selection. The filters
+          # are syntactically identical to Kubecost's "v2" filters [1] but only
+          # support a small set of filter fields, those being:
+          # - namespace
+          # - controllerKind
+          # - controllerName
+          # - label
+          # - annotation
+          #
+          # If multiple filters are listed, they will be ORed together at the top
+          # level.
+          #
+          # See the examples below.
+          #
+          # [1] https://docs.kubecost.com/apis/apis-overview/filters-api
+          # filterConfig:
+          #   - filter: |
+          #       namespace:"abc"+controllerKind:"deployment"
+          #   - filter: |
+          #       controllerName:"abc123"+controllerKind:"daemonset"
+          #   - filter: |
+          #       namespace:"foo"+controllerKind!:"statefulset"
+          #   - filter: |
+          #       namespace:"bar","baz"
+          #  schedule:
+          #   start: "2024-01-30T15:04:05Z"
+          #   frequencyMinutes: 5
+          #   recommendationQueryWindow: "48h"
+          #   lastModified: ''
+          #   targetUtilizationCPU: 0.8 # results in a cpu request setting that is 20% higher than the max seen over last 48h
+          #   targetUtilizationMemory: 0.8 # results in a RAM request setting that is 20% higher than the max seen over last 48h
+
+      kubescaler:
+        # If true, will cause all (supported) workloads to be have their requests
+        # automatically right-sized on a regular basis.
+        defaultResizeAll: false
+    #  fqdn: kubecost-cluster-controller.kubecost.svc.cluster.local:9731
+      namespaceTurndown:
+        rbac:
+          enabled: true
+      
+
+
+    kubecostDeployment:
+      statefulSet:
+        enabled: false
+      replicas: 1


### PR DESCRIPTION
**Description:**

This pull request introduces significant enhancements to the FluxCD configurations to better support enterprise users by integrating the Kubecost Actions and Carbon Costs functionalities directly within the setup process. These updates are aimed at maximizing cost savings and optimizing resource management within Kubernetes environments.

**Key Enhancements:**

1. **Structured FluxCD Configurations:**
   - I've refined the `helmrelease-plugins.yaml` configuration, distinct from the `helmrelease-flux-primary.yaml` and `helmrelease-flux-secondary.yaml`, to streamline the deployment of Kubecost Actions and Carbon Costs. This approach clarifies setup procedures on the primary cluster, facilitating easier management and deployment of these features.

2. **Integration of Kubecost Actions:**
   - The configuration now includes a consolidated overview of key Kubecost Actions such as Cluster Turndown, Request Sizing, and Namespace Turndown. For each action, brief descriptions are provided with directives to refer to the official [Kubecost Actions Documentation](https://docs.kubecost.com/using-kubecost/navigating-the-kubecost-ui/savings/savings-actions#enabling-kubecost-actions) for detailed information.

3. **Carbon Costs Configuration:**
   - Added new configuration details on how to integrate Carbon Costs into the Allocation and Assets dashboards, emphasizing the use of KG CO2e as a metric. This section guides users to the Cloud Carbon Footprint's methodology page for comprehensive insights into carbon cost calculations.

By centralizing and enhancing the FluxCD configurations for these key features, this contribution seeks to significantly ease the implementation and management of cost-saving and environmental sustainability tools within Kubernetes clusters. 

Collaboration Note:

I welcome and encourage feedback on this contribution. Please feel free to suggest edits, ask questions, or recommend improvements.
